### PR TITLE
Update bootloader.yul

### DIFF
--- a/bootloader/bootloader.yul
+++ b/bootloader/bootloader.yul
@@ -1152,10 +1152,6 @@ object "Bootloader" {
                 default {
                     gasLimitForTx := sub(gasLimitForTx, intrinsicOverhead)
                 }
-
-                // Making sure that the body of the transaction does not have more gas
-                // than allowed by DDoS safety
-                gasLimitForTx := min(MAX_GAS_PER_TRANSACTION(), gasLimitForTx)
             }
 
             /// @dev The function responsible for the L2 transaction validation.


### PR DESCRIPTION
We should limit the gas limit as it is controlled by the operator and it will be used to pay for bytecodes, so 80 million will not be usually enough for bytecodes